### PR TITLE
Deleted pointerEvents none

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,6 @@ export default class Toast extends Component {
         const view = this.state.isShow ?
             <View
                 style={[styles.container, { top: pos }]}
-                pointerEvents="none"
             >
                 <Animated.View
                     style={[styles.content, { opacity: this.state.opacityValue }, this.props.style]}


### PR DESCRIPTION
If you're try to clickable toast notification view has a pointerEvents none option can not give you permission for do it. That's why I removed that. You don't need pointerEvents none for like this components.